### PR TITLE
linux-libc-headers: additional musl fixes for libc-compat.h

### DIFF
--- a/recipes-kernel/linux-libc-headers/linux-libc-headers/fix-some-issues-arising-from-in6.h.patch
+++ b/recipes-kernel/linux-libc-headers/linux-libc-headers/fix-some-issues-arising-from-in6.h.patch
@@ -1,0 +1,74 @@
+From 3cd5b95ad2e9ca7d39e2dffe79f9198a36a0e68e Mon Sep 17 00:00:00 2001
+From: rofl0r <retnyg@gmx.net>
+Date: Wed, 22 Jan 2014 00:48:28 +0100
+Subject: [PATCH] libc-compat.h: fix some issues arising from in6.h
+
+namely redefinition of some structs provided by netinet/in.h.
+---
+ generic/include/linux/libc-compat.h | 23 +++++++----------------
+ 1 file changed, 7 insertions(+), 16 deletions(-)
+
+Index: linux-3.19/include/uapi/linux/libc-compat.h
+===================================================================
+--- linux-3.19.orig/include/uapi/linux/libc-compat.h
++++ linux-3.19/include/uapi/linux/libc-compat.h
+@@ -48,36 +48,27 @@
+ #ifndef _UAPI_LIBC_COMPAT_H
+ #define _UAPI_LIBC_COMPAT_H
+ 
+-/* We have included glibc headers... */
+-#if defined(__GLIBC__)
++#ifndef __KERNEL__ /* we're used from userspace */
+ 
+-/* Coordinate with glibc netinet/in.h header. */
++/* Coordinate with libc netinet/in.h header. */
+ #if defined(_NETINET_IN_H)
+ 
+-/* GLIBC headers included first so don't define anything
++/* libc headers included first so don't define anything
+  * that would already be defined. */
+ #define __UAPI_DEF_IN6_ADDR		0
+-/* The exception is the in6_addr macros which must be defined
+- * if the glibc code didn't define them. This guard matches
+- * the guard in glibc/inet/netinet/in.h which defines the
+- * additional in6_addr macros e.g. s6_addr16, and s6_addr32. */
+-#if defined(__USE_MISC) || defined (__USE_GNU)
+ #define __UAPI_DEF_IN6_ADDR_ALT		0
+-#else
+-#define __UAPI_DEF_IN6_ADDR_ALT		1
+-#endif
+ #define __UAPI_DEF_SOCKADDR_IN6		0
+ #define __UAPI_DEF_IPV6_MREQ		0
+ #define __UAPI_DEF_IPPROTO_V6		0
+ #define __UAPI_DEF_IPV6_OPTIONS		0
+ 
+-#else
++#else /* defined(_NETINET_IN_H) */
+ 
+ /* Linux headers included first, and we must define everything
+- * we need. The expectation is that glibc will check the
++ * we need. The expectation is that the libc will check the
+  * __UAPI_DEF_* defines and adjust appropriately. */
+ #define __UAPI_DEF_IN6_ADDR		1
+-/* We unconditionally define the in6_addr macros and glibc must
++/* We unconditionally define the in6_addr macros and libc must
+  * coordinate. */
+ #define __UAPI_DEF_IN6_ADDR_ALT		1
+ #define __UAPI_DEF_SOCKADDR_IN6		1
+@@ -97,7 +88,7 @@
+ /* If we did not see any headers from any supported C libraries,
+  * or we are being included in the kernel, then define everything
+  * that we need. */
+-#else /* !defined(__GLIBC__) */
++#else /* __KERNEL__ */
+ 
+ /* Definitions for in6.h */
+ #define __UAPI_DEF_IN6_ADDR		1
+@@ -110,6 +101,6 @@
+ /* Definitions for xattr.h */
+ #define __UAPI_DEF_XATTR		1
+ 
+-#endif /* __GLIBC__ */
++#endif /* __KERNEL__ */
+ 
+ #endif /* _UAPI_LIBC_COMPAT_H */

--- a/recipes-kernel/linux-libc-headers/linux-libc-headers/prevent-redefinition-of-struct-ethhdr.patch
+++ b/recipes-kernel/linux-libc-headers/linux-libc-headers/prevent-redefinition-of-struct-ethhdr.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] libc-compat.h: prevent redefinition of struct ethhdr
  generic/include/linux/libc-compat.h | 6 ++++++
  2 files changed, 9 insertions(+), 1 deletion(-)
 
-Index: linux-3.17.7/include/uapi/linux/if_ether.h
+Index: linux-3.19/include/uapi/linux/if_ether.h
 ===================================================================
---- linux-3.17.7.orig/include/uapi/linux/if_ether.h
-+++ linux-3.17.7/include/uapi/linux/if_ether.h
+--- linux-3.19.orig/include/uapi/linux/if_ether.h
++++ linux-3.19/include/uapi/linux/if_ether.h
 @@ -22,6 +22,7 @@
  #define _UAPI_LINUX_IF_ETHER_H
  
@@ -20,7 +20,7 @@ Index: linux-3.17.7/include/uapi/linux/if_ether.h
  
  /*
   *	IEEE 802.3 Ethernet magic constants.  The frame sizes omit the preamble
-@@ -133,11 +134,12 @@
+@@ -134,11 +135,12 @@
   *	This is an Ethernet frame header.
   */
  
@@ -34,13 +34,13 @@ Index: linux-3.17.7/include/uapi/linux/if_ether.h
 +#endif
  
  #endif /* _UAPI_LINUX_IF_ETHER_H */
-Index: linux-3.17.7/include/uapi/linux/libc-compat.h
+Index: linux-3.19/include/uapi/linux/libc-compat.h
 ===================================================================
---- linux-3.17.7.orig/include/uapi/linux/libc-compat.h
-+++ linux-3.17.7/include/uapi/linux/libc-compat.h
-@@ -48,6 +48,12 @@
- #ifndef _UAPI_LIBC_COMPAT_H
- #define _UAPI_LIBC_COMPAT_H
+--- linux-3.19.orig/include/uapi/linux/libc-compat.h
++++ linux-3.19/include/uapi/linux/libc-compat.h
+@@ -50,6 +50,12 @@
+ 
+ #ifndef __KERNEL__ /* we're used from userspace */
  
 +#ifdef _NETINET_IF_ETHER_H /* musl */
 +#define __UAPI_DEF_ETHHDR 0
@@ -48,6 +48,6 @@ Index: linux-3.17.7/include/uapi/linux/libc-compat.h
 +#define __UAPI_DEF_ETHHDR 1
 +#endif
 +
- /* We have included glibc headers... */
- #if defined(__GLIBC__)
+ /* Coordinate with libc netinet/in.h header. */
+ #if defined(_NETINET_IN_H)
  

--- a/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,5 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI_append_libc-musl = "\
-            file://prevent-redefinition-of-struct-ethhdr.patch \
-           "
+    file://fix-some-issues-arising-from-in6.h.patch \
+    file://prevent-redefinition-of-struct-ethhdr.patch \
+"


### PR DESCRIPTION
Port fix-some-issues-arising-from-in6.h.patch from:

  https://github.com/sabotage-linux/kernel-headers/commit/3cd5b95ad2e9ca7d39e2dffe79f9198a36a0e68e

This patch fixes issues seen when building lxc with musl libc:

  | i586-rdk-linux-musl-gcc  -m32 -march=core2 -mtune=core2 -msse3 -mfpmath=sse --sysroot=/home/andre/rdk/rdk-master-musl/build-vbox32/tmp/sysroots/vbox32 -DHAVE_CONFIG_H -I. -I/home/andre/rdk/rdk-master-musl/build-vbox32/tmp/work/core2-32-rdk-linux-musl/lxc/1.0.7-r0/lxc-1.0.7/src/lxc -I../../src    -I/home/andre/rdk/rdk-master-musl/build-vbox32/tmp/work/core2-32-rdk-linux-musl/lxc/1.0.7-r0/lxc-1.0.7/src -DLXCROOTFSMOUNT=\"/usr/lib/lxc/rootfs\" -DLXCPATH=\"/var/lib/lxc\" -DLXC_GLOBAL_CONF=\"/etc/lxc/lxc.conf\" -DLXCINITDIR=\"/usr/lib/lxc\" -DLIBEXECDIR=\"/usr/lib/lxc\" -DLXCTEMPLATEDIR=\"/usr/share/lxc/templates\" -DLOGPATH=\"/var/log/lxc\" -DLXC_DEFAULT_CONFIG=\"/etc/lxc/default.conf\" -DLXC_USERNIC_DB=\"/run/lxc/nics\" -DLXC_USERNIC_CONF=\"/etc/lxc/lxc-usernet\" -DDEFAULT_CGROUP_PATTERN=\"/lxc/%n\" -DRUNTIME_PATH=\"/run\" -DSBINDIR=\"/usr/sbin\"      -O2 -pipe -g -feliminate-unused-debug-types -Wall -Werror -c -o network.o /home/andre/rdk/rdk-master-musl/build-vbox32/tmp/work/core2-32-rdk-linux-musl/lxc/1.0.7-r0/lxc-1.0.7/src/lxc/network.c
  | In file included from /home/andre/rdk/rdk-master-musl/build-vbox32/tmp/sysroots/vbox32/usr/include/linux/if_bridge.h:18:0,
  |                  from /home/andre/rdk/rdk-master-musl/build-vbox32/tmp/work/core2-32-rdk-linux-musl/lxc/1.0.7-r0/lxc-1.0.7/src/lxc/lxc_user_nic.c:43:
  | /home/andre/rdk/rdk-master-musl/build-vbox32/tmp/sysroots/vbox32/usr/include/linux/in6.h:32:8: error: redefinition of 'struct in6_addr'
  |  struct in6_addr {
  |         ^
  | In file included from /home/andre/rdk/rdk-master-musl/build-vbox32/tmp/sysroots/vbox32/usr/include/arpa/inet.h:9:0,
  |                  from /home/andre/rdk/rdk-master-musl/build-vbox32/tmp/work/core2-32-rdk-linux-musl/lxc/1.0.7-r0/lxc-1.0.7/src/lxc/lxc_user_nic.c:39:
  | /home/andre/rdk/rdk-master-musl/build-vbox32/tmp/sysroots/vbox32/usr/include/netinet/in.h:24:8: note: originally defined here
  |  struct in6_addr
  |         ^
  | ...

Signed-off-by: Andre McCurdy <armccurdy@gmail.com>