### PR TITLE
llvm3.3: musl fixes

### DIFF
--- a/recipes-core/llvm/llvm3.3/musl-fixes.patch
+++ b/recipes-core/llvm/llvm3.3/musl-fixes.patch
@@ -1,0 +1,201 @@
+From 01a2401b8e61e2192179a47d4fc3956e8a04caf8 Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Thu, 18 Jun 2015 18:24:14 -0700
+Subject: [PATCH] musl fixes
+
+Minimal set of musl fixes, based on:
+
+  https://github.com/sabotage-linux/sabotage/blob/master/KEEP/llvm34.patch
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ autoconf/config.sub                     |  1 +
+ include/llvm/Target/TargetLibraryInfo.h |  8 --------
+ lib/Support/DynamicLibrary.cpp          |  2 +-
+ lib/Support/Unix/Signals.inc            |  2 +-
+ lib/Target/TargetLibraryInfo.cpp        |  8 --------
+ lib/Transforms/IPO/FunctionAttrs.cpp    | 24 ------------------------
+ projects/sample/autoconf/config.sub     |  1 +
+ 7 files changed, 4 insertions(+), 42 deletions(-)
+
+diff --git a/autoconf/config.sub b/autoconf/config.sub
+index a8d8528..effdfaa 100755
+--- a/autoconf/config.sub
++++ b/autoconf/config.sub
+@@ -125,6 +125,7 @@ esac
+ maybe_os=`echo $1 | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\2/'`
+ case $maybe_os in
+   nto-qnx* | linux-gnu* | linux-android* | linux-dietlibc | linux-newlib* | \
++  linux-musl* | \
+   linux-uclibc* | uclinux-uclibc* | uclinux-gnu* | kfreebsd*-gnu* | \
+   knetbsd*-gnu* | netbsd*-gnu* | \
+   kopensolaris*-gnu* | \
+diff --git a/include/llvm/Target/TargetLibraryInfo.h b/include/llvm/Target/TargetLibraryInfo.h
+index 5f01c8d..26e4b9c 100644
+--- a/include/llvm/Target/TargetLibraryInfo.h
++++ b/include/llvm/Target/TargetLibraryInfo.h
+@@ -237,8 +237,6 @@ namespace llvm {
+       fmodl,
+       /// FILE *fopen(const char *filename, const char *mode);
+       fopen,
+-      /// FILE *fopen64(const char *filename, const char *opentype)
+-      fopen64,
+       /// int fprintf(FILE *stream, const char *format, ...);
+       fprintf,
+       /// int fputc(int c, FILE *stream);
+@@ -261,8 +259,6 @@ namespace llvm {
+       fseek,
+       /// int fseeko(FILE *stream, off_t offset, int whence);
+       fseeko,
+-      /// int fseeko64(FILE *stream, off64_t offset, int whence)
+-      fseeko64,
+       /// int fsetpos(FILE *stream, const fpos_t *pos);
+       fsetpos,
+       /// int fstat(int fildes, struct stat *buf);
+@@ -277,8 +273,6 @@ namespace llvm {
+       ftell,
+       /// off_t ftello(FILE *stream);
+       ftello,
+-      /// off64_t ftello64(FILE *stream)
+-      ftello64,
+       /// int ftrylockfile(FILE *file);
+       ftrylockfile,
+       /// void funlockfile(FILE *file);
+@@ -582,8 +576,6 @@ namespace llvm {
+       times,
+       /// FILE *tmpfile(void);
+       tmpfile,
+-      /// FILE *tmpfile64(void)
+-      tmpfile64,
+       /// int toascii(int c);
+       toascii,
+       /// double trunc(double x);
+diff --git a/lib/Support/DynamicLibrary.cpp b/lib/Support/DynamicLibrary.cpp
+index f14cb45..d331b91 100644
+--- a/lib/Support/DynamicLibrary.cpp
++++ b/lib/Support/DynamicLibrary.cpp
+@@ -160,7 +160,7 @@ void* DynamicLibrary::SearchForAddressOfSymbol(const char *symbolName) {
+ // On linux we have a weird situation. The stderr/out/in symbols are both
+ // macros and global variables because of standards requirements. So, we
+ // boldly use the EXPLICIT_SYMBOL macro without checking for a #define first.
+-#if defined(__linux__) and !defined(__ANDROID__)
++#if defined(__GLIBC__)
+   {
+     EXPLICIT_SYMBOL(stderr);
+     EXPLICIT_SYMBOL(stdout);
+diff --git a/lib/Support/Unix/Signals.inc b/lib/Support/Unix/Signals.inc
+index 64d1fc1..f08e6b5 100644
+--- a/lib/Support/Unix/Signals.inc
++++ b/lib/Support/Unix/Signals.inc
+@@ -268,7 +268,7 @@ void llvm::sys::AddSignalHandler(void (*FnPtr)(void *), void *Cookie) {
+ // On glibc systems we have the 'backtrace' function, which works nicely, but
+ // doesn't demangle symbols.
+ void llvm::sys::PrintStackTrace(FILE *FD) {
+-#if defined(HAVE_BACKTRACE) && defined(ENABLE_BACKTRACES)
++#if defined(__GLIBC__) && defined(HAVE_BACKTRACE) && defined(ENABLE_BACKTRACES)
+   static void* StackTrace[256];
+   // Use backtrace() to output a backtrace on Linux systems with glibc.
+   int depth = backtrace(StackTrace,
+diff --git a/lib/Target/TargetLibraryInfo.cpp b/lib/Target/TargetLibraryInfo.cpp
+index ee88ce7..81e6ed1 100644
+--- a/lib/Target/TargetLibraryInfo.cpp
++++ b/lib/Target/TargetLibraryInfo.cpp
+@@ -133,7 +133,6 @@ const char* TargetLibraryInfo::StandardNames[LibFunc::NumLibFuncs] =
+     "fmodf",
+     "fmodl",
+     "fopen",
+-    "fopen64",
+     "fprintf",
+     "fputc",
+     "fputs",
+@@ -145,7 +144,6 @@ const char* TargetLibraryInfo::StandardNames[LibFunc::NumLibFuncs] =
+     "fscanf",
+     "fseek",
+     "fseeko",
+-    "fseeko64",
+     "fsetpos",
+     "fstat",
+     "fstat64",
+@@ -153,7 +151,6 @@ const char* TargetLibraryInfo::StandardNames[LibFunc::NumLibFuncs] =
+     "fstatvfs64",
+     "ftell",
+     "ftello",
+-    "ftello64",
+     "ftrylockfile",
+     "funlockfile",
+     "fwrite",
+@@ -303,7 +300,6 @@ const char* TargetLibraryInfo::StandardNames[LibFunc::NumLibFuncs] =
+     "tanl",
+     "times",
+     "tmpfile",
+-    "tmpfile64",
+     "toascii",
+     "trunc",
+     "truncf",
+@@ -563,16 +559,12 @@ static void initialize(TargetLibraryInfo &TLI, const Triple &T,
+     TLI.setUnavailable(LibFunc::under_IO_getc);
+     TLI.setUnavailable(LibFunc::under_IO_putc);
+     TLI.setUnavailable(LibFunc::memalign);
+-    TLI.setUnavailable(LibFunc::fopen64);
+-    TLI.setUnavailable(LibFunc::fseeko64);
+     TLI.setUnavailable(LibFunc::fstat64);
+     TLI.setUnavailable(LibFunc::fstatvfs64);
+-    TLI.setUnavailable(LibFunc::ftello64);
+     TLI.setUnavailable(LibFunc::lstat64);
+     TLI.setUnavailable(LibFunc::open64);
+     TLI.setUnavailable(LibFunc::stat64);
+     TLI.setUnavailable(LibFunc::statvfs64);
+-    TLI.setUnavailable(LibFunc::tmpfile64);
+   }
+ }
+ 
+diff --git a/lib/Transforms/IPO/FunctionAttrs.cpp b/lib/Transforms/IPO/FunctionAttrs.cpp
+index bc5109b..ed84dbe 100644
+--- a/lib/Transforms/IPO/FunctionAttrs.cpp
++++ b/lib/Transforms/IPO/FunctionAttrs.cpp
+@@ -1271,30 +1271,6 @@ bool FunctionAttrs::inferPrototypeAttributes(Function &F) {
+     setDoesNotCapture(F, 1);
+     setDoesNotCapture(F, 2);
+     break;
+-  case LibFunc::fopen64:
+-    if (FTy->getNumParams() != 2 ||
+-        !FTy->getReturnType()->isPointerTy() ||
+-        !FTy->getParamType(0)->isPointerTy() ||
+-        !FTy->getParamType(1)->isPointerTy())
+-      return false;
+-    setDoesNotThrow(F);
+-    setDoesNotAlias(F, 0);
+-    setDoesNotCapture(F, 1);
+-    setDoesNotCapture(F, 2);
+-    break;
+-  case LibFunc::fseeko64:
+-  case LibFunc::ftello64:
+-    if (FTy->getNumParams() == 0 || !FTy->getParamType(0)->isPointerTy())
+-      return false;
+-    setDoesNotThrow(F);
+-    setDoesNotCapture(F, 1);
+-    break;
+-  case LibFunc::tmpfile64:
+-    if (!FTy->getReturnType()->isPointerTy())
+-      return false;
+-    setDoesNotThrow(F);
+-    setDoesNotAlias(F, 0);
+-    break;
+   case LibFunc::fstat64:
+   case LibFunc::fstatvfs64:
+     if (FTy->getNumParams() != 2 || !FTy->getParamType(1)->isPointerTy())
+diff --git a/projects/sample/autoconf/config.sub b/projects/sample/autoconf/config.sub
+index 9d22c1e..e47a5cd 100755
+--- a/projects/sample/autoconf/config.sub
++++ b/projects/sample/autoconf/config.sub
+@@ -125,6 +125,7 @@ esac
+ maybe_os=`echo $1 | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\2/'`
+ case $maybe_os in
+   nto-qnx* | linux-gnu* | linux-android* | linux-dietlibc | linux-newlib* | \
++  linux-musl* | \
+   linux-uclibc* | uclinux-uclibc* | uclinux-gnu* | kfreebsd*-gnu* | \
+   knetbsd*-gnu* | netbsd*-gnu* | \
+   kopensolaris*-gnu* | \
+-- 
+1.9.1
+

--- a/recipes-core/llvm/llvm3.3_%.bbappend
+++ b/recipes-core/llvm/llvm3.3_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append_libc-musl = " file://musl-fixes.patch"

--- a/recipes-graphics/mesa/mesa/musl-fixes.patch
+++ b/recipes-graphics/mesa/mesa/musl-fixes.patch
@@ -1,0 +1,28 @@
+From f892cf9ebd7dbb5b5d30d3240bfa679b51bd8465 Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Fri, 19 Jun 2015 20:21:18 -0700
+Subject: [PATCH] musl fixes
+
+Use PTHREAD_MUTEX_RECURSIVE iso PTHREAD_MUTEX_RECURSIVE_NP.
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ include/c11/threads_posix.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/c11/threads_posix.h b/include/c11/threads_posix.h
+index f9c165d..cdf6820 100644
+--- a/include/c11/threads_posix.h
++++ b/include/c11/threads_posix.h
+@@ -178,7 +178,7 @@ mtx_init(mtx_t *mtx, int type)
+         return thrd_error;
+     pthread_mutexattr_init(&attr);
+     if ((type & mtx_recursive) != 0) {
+-#if defined(__linux__) || defined(__linux)
++#if defined(__GLIBC__)
+         pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP);
+ #else
+         pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+-- 
+1.9.1
+

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append_libc-musl = " file://musl-fixes.patch"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-libav/musl-fixes.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-libav/musl-fixes.patch
@@ -1,0 +1,31 @@
+From 8716fc355602445cb17a81def5a9465b00a8b0dc Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Fri, 19 Jun 2015 15:18:54 -0700
+Subject: [PATCH] musl fixes
+
+Define _GNU_SOURCE via cppflags for libav so that:
+
+  #include <time.h> provides strptime
+  #include <math.h> provides M_SQRT2 and M_SQRT1_2
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ gst-libs/ext/libav/configure | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/gst-libs/ext/libav/configure b/gst-libs/ext/libav/configure
+index 10d053e..6e522ea 100755
+--- a/gst-libs/ext/libav/configure
++++ b/gst-libs/ext/libav/configure
+@@ -3170,6 +3170,8 @@ check_cc -D_LARGEFILE_SOURCE <<EOF && add_cppflags -D_LARGEFILE_SOURCE
+ #include <stdlib.h>
+ EOF
+ 
++add_cppflags -D_GNU_SOURCE
++
+ add_host_cppflags -D_ISOC99_SOURCE
+ check_host_cflags -std=c99
+ check_host_cflags -Wall
+-- 
+1.9.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-libav_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-libav_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://musl-fixes.patch"


### PR DESCRIPTION
Minimal set of musl fixes, based on:

  https://github.com/sabotage-linux/sabotage/blob/master/KEEP/llvm34.patch

Signed-off-by: Andre McCurdy <armccurdy@gmail.com>