### PR TITLE
busybox: apply use-POSIX-getpwent patch to 1.23.x only

### DIFF
--- a/recipes-core/busybox/busybox_%.bbappend
+++ b/recipes-core/busybox/busybox_%.bbappend
@@ -1,7 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI_append_libc-musl = " file://musl.cfg"
-
-SRC_URI += "\
-            file://0001-linedit-deluser-use-POSIX-getpwent-instead-of-getpwe.patch \
-           "

--- a/recipes-core/busybox/busybox_1.23.%.bbappend
+++ b/recipes-core/busybox/busybox_1.23.%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += "\
+            file://0001-linedit-deluser-use-POSIX-getpwent-instead-of-getpwe.patch \
+           "


### PR DESCRIPTION
Patch is no longer applicable for upcoming busybox 1.24

Signed-off-by: Andre McCurdy <armccurdy@gmail.com>